### PR TITLE
Update core.js

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -35,10 +35,26 @@
 
 // Utilities
 
-  var typeObj = {};
-  function typeOf(obj) {
-    return typeObj.toString.call(obj).match(/\s([a-zA-Z]+)/)[1].toLowerCase();
-  }
+  // a bit more prolix but ways faster and better suitable for mobile
+  // than the one used before: http://jsperf.com/generic-typeof
+  // also once minzipped ain't so bigger ;-)
+  var typeOf = (function(Object, RegExp){
+    // WTFPL License - http://en.wikipedia.org/wiki/WTFPL
+    var toString = Object.prototype.toString,
+      cache = (Object.create || Object)(null),
+      matchClass = /\w+(?=])/;
+    return function typeOf(Unknown) {
+      var asString = typeof Unknown;
+      return asString == 'object' ? (
+        Unknown === null ? 'null' : (
+          cache[asString = toString.call(Unknown)] || (
+            cache[asString] = matchClass.test(asString) &&
+                              RegExp.lastMatch.toLowerCase()
+          )
+        )
+      ) : asString;
+    };
+  }(Object, RegExp));
 
   function clone(item, type){
     var fn = clone[type || typeOf(item)];


### PR DESCRIPTION
as you can [verify in this page](http://jsperf.com/typeof) the previously used `typeOf` function, potentially invoked many times during a mobile app lifecycle, is much slower plus it creates a lot of garbage (a `new RegExp` each call and its matched `Array`).

If one of this wonderful library goal is to make it usable from all devices out there, a consideration for these kind of tweaks would be highly appreciated.

The current version is using a smart technique to reach best performance and cost almost nothing from the second time it gets invoked with similar types or objects and it avoids the creation of garbage. The number of static strings increases potentially with variety of native instances passed to the callback but these won't be a warning number with current ES3 to 6 specs/scenario.

Please accept this patch or at least avoid creating garbage each time with a version like the following one (still not as fast as the one proposed in this patch)

``` javascript
var typeObj = {};
var re = /\w+(?=])/;
function typeOf2(obj) {
  return re.test(typeObj.toString.call(obj)) &&
         RegExp.lastMatch.toLowerCase();
}
```

Best Regards
