### PR TITLE
Fix x-tags when used with AMD

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -936,8 +936,8 @@ if (win.TouchEvent) {
     }
   };
 
+  win.xtag = xtag
   if (typeof define == 'function' && define.amd) define(xtag);
-  else win.xtag = xtag;
 
   doc.addEventListener('WebComponentsReady', function(){
     xtag.fireEvent(doc.body, 'DOMComponentsLoaded');


### PR DESCRIPTION
When x-tags is used as an AMD module, it expects `xtag` to be in the global scope, but it won't be there if `define()` is present and AMD-compatible. `xtag` should simply always be in the global scope.

/cc @potch @spasovski
