### PR TITLE
native CustomElements  (on Chrome Canary) doesn't handle undefined 'extends'

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -364,11 +364,13 @@
               .constructor).prototype :
           win.HTMLElement.prototype;
 
-      return doc.register(_name, {
-        'extends': options['extends'],
+      var definition = {
         'prototype': Object.create(elementProto, tag.prototype)
-      });
-
+      };
+      if (options['extends']) {
+        definition['extends'] = options['extends'];
+      }
+      return doc.register(_name, definition);
     },
 
     /* Exposed Variables */


### PR DESCRIPTION
... this patch avoids that option if 'extends' is undefined
