### PR TITLE
queryChildren Fix

### DIFF
--- a/spec/core.js
+++ b/spec/core.js
@@ -1013,11 +1013,19 @@ describe("x-tag ", function () {
           },
           click: function (e, elem){
             if (e.currentTarget == foo) count++;
-          }
+          },
+          barf: function(e, elem){
+            if (e.currentTarget == foo) count++;
+          },
+          'barf:delegate(div)': function(e, elem){
+            if (e.currentTarget == foo) count++;
+          },
         }
       });
 
       foo = document.createElement('x-foo30');
+      var d1 = document.createElement('div');
+      foo.appendChild(d1);
       var foo2 = document.createElement('x-foo30');
       testbox.appendChild(foo);
       testbox.appendChild(foo2);
@@ -1027,13 +1035,14 @@ describe("x-tag ", function () {
       foo.dispatchEvent(event);
 
       xtag.fireEvent(foo, 'bar');
+      xtag.fireEvent(d1, 'barf');
 
       waitsFor(function(){
-        return count == 2;
+        return count == 4;
       }, 'both clicks to bubble', 1000);
 
       runs(function (){
-        expect(count).toEqual(2);
+        expect(count).toEqual(4);
       });
 
     });
@@ -1256,15 +1265,22 @@ describe("x-tag ", function () {
 
       });
 
-
       it('queryChildren', function(){
         testbox.appendChild(document.createElement('a'));
         testbox.appendChild(document.createElement('a'));
         var div = document.createElement('div');
         div.appendChild(document.createElement('a'));
         testbox.appendChild(div);
-
         expect(2).toEqual(xtag.queryChildren(testbox, 'a').length);
+        expect(div.parentElement).toBeDefined();
+      });
+
+      it('queryChildren no parent', function(){
+        var div = document.createElement('div');
+        div.appendChild(document.createElement('a'));
+        div.appendChild(document.createElement('a'));
+        expect(2).toEqual(xtag.queryChildren(div, 'a').length);
+        expect(div.parentElement).toBeNull();
       });
 
     });

--- a/src/core.js
+++ b/src/core.js
@@ -4,6 +4,7 @@
 
   var win = window,
     doc = document,
+    container = doc.createElement('div'),
     noop = function(){},
     trueop = function(){ return true; },
     regexPseudoSplit = /([\w-]+(?:\([^\)]+\))?)/g,
@@ -197,7 +198,7 @@
   }
 
   var skipProps = {};
-  for (var z in document.createEvent('CustomEvent')) skipProps[z] = 1;
+  for (var z in doc.createEvent('CustomEvent')) skipProps[z] = 1;
   function inheritEvent(event, base){
     var desc = Object.getOwnPropertyDescriptor(event, 'target');
     for (var z in base) {
@@ -650,10 +651,18 @@
     queryChildren: function (element, selector) {
       var id = element.id,
         guid = element.id = id || 'x_' + xtag.uid(),
-        attr = '#' + guid + ' > ';
+        attr = '#' + guid + ' > ',
+        noParent = false;
+      if (!element.parentNode){
+        noParent = true;
+        container.appendChild(element);
+      }
       selector = attr + (selector + '').replace(',', ',' + attr, 'g');
       var result = element.parentNode.querySelectorAll(selector);
       if (!id) element.removeAttribute('id');
+      if (noParent){
+        container.removeChild(element);
+      }
       return toArray(result);
     },
 


### PR DESCRIPTION
If there isn't a parentNode then 
1. create a div 
2. stash the element inside it
3. do the query
4. remove the parent node
5. return the results

https://github.com/x-tag/core/issues/65
