### PR TITLE
Added the parent[Node|Element] to element.xtag. During lifecycle.removed...

### DIFF
--- a/dist/x-tag-core.js
+++ b/dist/x-tag-core.js
@@ -1230,9 +1230,13 @@ function _inserted(element) {
       if (element.__inserted > 1) {
         logFlags.dom && console.warn('inserted:', element.localName,
           'insert/remove count:', element.__inserted)
-      } else if (element.attachedCallback) {
-        logFlags.dom && console.log('inserted:', element.localName);
-        element.attachedCallback();
+      } else {
+        element.xtag.parentNode = element.parentNode;
+        element.xtag.parentElement = element.parentElement;
+        if (element.attachedCallback) {
+          logFlags.dom && console.log('inserted:', element.localName);
+          element.attachedCallback();
+        }
       }
     }
     logFlags.dom && console.groupEnd();
@@ -1272,8 +1276,19 @@ function _removed(element) {
       if (element.__inserted < 0) {
         logFlags.dom && console.warn('removed:', element.localName,
             'insert/remove count:', element.__inserted)
-      } else if (element.detachedCallback) {
-        element.detachedCallback();
+      } else {
+        //copy parent to sematically correct property
+        element.xtag.previousParentNode = element.xtag.parentNode;
+        element.xtag.previousParentElement = element.xtag.parentElement;
+        //remove parent because it is no longer valid
+        element.xtag.parentNode = undefined;
+        element.xtag.parentElement = undefined;
+        if (element.detachedCallback) {
+          element.detachedCallback();
+        }
+        //remove previous parent because it is no longer required
+        element.xtag.previousParentNode = undefined;
+        element.xtag.previousParentElement = undefined;
       }
     }
     logFlags.dom && console.groupEnd();

--- a/lib/web-components-polyfills.js
+++ b/lib/web-components-polyfills.js
@@ -1230,9 +1230,13 @@ function _inserted(element) {
       if (element.__inserted > 1) {
         logFlags.dom && console.warn('inserted:', element.localName,
           'insert/remove count:', element.__inserted)
-      } else if (element.attachedCallback) {
-        logFlags.dom && console.log('inserted:', element.localName);
-        element.attachedCallback();
+      } else {
+        element.xtag.parentNode = element.parentNode;
+        element.xtag.parentElement = element.parentElement;
+        if (element.attachedCallback) {
+          logFlags.dom && console.log('inserted:', element.localName);
+          element.attachedCallback();
+        }
       }
     }
     logFlags.dom && console.groupEnd();
@@ -1272,8 +1276,19 @@ function _removed(element) {
       if (element.__inserted < 0) {
         logFlags.dom && console.warn('removed:', element.localName,
             'insert/remove count:', element.__inserted)
-      } else if (element.detachedCallback) {
-        element.detachedCallback();
+      } else {
+        //copy parent to sematically correct property
+        element.xtag.previousParentNode = element.xtag.parentNode;
+        element.xtag.previousParentElement = element.xtag.parentElement;
+        //remove parent because it is no longer valid
+        element.xtag.parentNode = undefined;
+        element.xtag.parentElement = undefined;
+        if (element.detachedCallback) {
+          element.detachedCallback();
+        }
+        //remove previous parent because it is no longer required
+        element.xtag.previousParentNode = undefined;
+        element.xtag.previousParentElement = undefined;
       }
     }
     logFlags.dom && console.groupEnd();

--- a/spec/core.js
+++ b/spec/core.js
@@ -417,6 +417,29 @@ describe("x-tag ", function () {
       });
     });
 
+    it('previous parent should be available on lifcycle.removed', function (){
+      var parent_available = false;
+      xtag.register('x-foo5-removed-previous-parent', {
+        lifecycle: {
+          removed: function() {
+              parent_available = !!(this.xtag.previousParentNode && (this.xtag.previousParentElement || !document.body.parentElement));
+          }
+        } 
+      });
+      var foo = document.createElement('x-foo5-removed-previous-parent');
+      testbox.appendChild(foo);
+      setTimeout(function(){
+        testbox.removeChild(foo);
+      },100);
+      waitsFor(function (){
+        return parent_available;
+      }, "new tag removed should fire providing the previous parent", 1000);
+
+      runs(function (){
+        expect(parent_available).toEqual(true);
+      });
+    });
+      
     it('should parse new tag as soon as it is registered', function (){
       var foo = document.createElement('x-foo6');
 


### PR DESCRIPTION
... the previous parent is available via this.xtag.parent[Node|Element]. Also added test for this.
Fixed #63.
As far as I see the only solution is to store the parentNode in the xtag property.
