### PR TITLE
Element pseudos

### DIFF
--- a/spec/core.js
+++ b/spec/core.js
@@ -1042,6 +1042,70 @@ describe("x-tag ", function () {
 
     });
 
+    it('it should allow pseudoe execution reordering', function(){
+      var order = '';
+      xtag.register('x-foo-el-pseudo2', {
+        accessors:{
+          'hi':{
+            'set:beep': function(val){
+              console.log('set:this', this);
+              order += "set"+val;
+            }
+          }
+        },
+        pseudos:{
+          beep: {
+            reverseFn: true, //  reverse the order that this pseudo gets applied.
+            onCompiled: function(fn, pseudo){
+              // it's pretty difficult to pull off reordering here,
+              // what if we had an option on this pseudo object
+              // that told applyPseudos to swap the functions ?
+              return fn;
+            },
+            action: function(pseudo, event){
+              console.log('action', this);
+              order += "beep";
+            }
+          }
+        }
+      });
+
+      var foo = document.createElement('x-foo-el-pseudo2');
+      foo.hi = 'foo';
+      expect(order).toEqual("compilesetfoobeep");
+
+    });
+
+    it('it should allow pseudoe onAdd hook for various disco tasks', function(){
+      var order = '';
+      xtag.register('x-foo-el-pseudo3', {
+        accessors:{
+          'hi':{
+            'set:beep': function(val){
+              order += "set";
+            }
+          }
+        },
+        pseudos:{
+          beep: {
+            onAdd: function(pseudo){
+              console.log('onAdd', pseudo)
+              order += "onAdd";
+              return null;
+            },
+            action: function(pseudo, event){
+              order += "action";
+            }
+          }
+        }
+      });
+
+      var foo = document.createElement('x-foo-el-pseudo3');
+      foo.hi = 'foo';
+      expect(order).toEqual("onAddactionset");
+
+    });
+
     it('setter foo should setAttribute foo on target', function (){
 
       xtag.register('x-foo25', {

--- a/src/core.js
+++ b/src/core.js
@@ -377,8 +377,8 @@
               this[attr.key] = attr.boolean ? hasAttr : this.getAttribute(name);
             }
           }
-          tag.pseudos.forEach(function(obj){
-            obj.onAdd.call(element, obj);
+          Object.keys(tag.pseudos).forEach(function(key){
+            if(tag.pseudos[key] && tag.pseudos[key].onAdd) tag.pseudos[key].onAdd.call(element, tag.pseudos[key]);
           });
           return output;
         }
@@ -794,7 +794,7 @@
             };
             if (target && pseudo.onAdd) {
               if (target.nodeName) pseudo.onAdd.call(target, pseudo);
-              else target.push(pseudo);
+              else target[name] = pseudo;
             }
           });
         }


### PR DESCRIPTION
Currently pseudos are only global.  This PR allows for element pseudos.    It's usefully for when you have some function that you need to run over and over again for a bunch of accessors that is only useful within the scope of the element.
