### PR TITLE
Fix bug with FireFox 5

### DIFF
--- a/src/core-refresh.js
+++ b/src/core-refresh.js
@@ -915,7 +915,7 @@
       event._attach.forEach(function(obj) {
         xtag.removeEvent(element, obj);
       });
-      element.removeEventListener(event.type, event.stack);
+      element.removeEventListener(event.type, event.stack, false);
     },
 
     removeEvents: function(element, obj){
@@ -1047,13 +1047,13 @@ for (z in UIEventProto){
   function addTap(el, tap, e){
     if (!el.__tap__) {
       el.__tap__ = { click: e.type == 'mousedown' };
-      if (el.__tap__.click) el.addEventListener('click', tap.observer);
+      if (el.__tap__.click) el.addEventListener('click', tap.observer, false);
       else {
         el.__tap__.scroll = tap.observer.bind(el);
         window.addEventListener('scroll', el.__tap__.scroll, true);
-        el.addEventListener('touchmove', tap.observer);
-        el.addEventListener('touchcancel', tap.observer);
-        el.addEventListener('touchend', tap.observer);
+        el.addEventListener('touchmove', tap.observer, false);
+        el.addEventListener('touchcancel', tap.observer, false);
+        el.addEventListener('touchend', tap.observer, false);
       }
     }
     if (!el.__tap__.click) {
@@ -1064,12 +1064,12 @@ for (z in UIEventProto){
 
   function removeTap(el, tap){
     if (el.__tap__) {
-      if (el.__tap__.click) el.removeEventListener('click', tap.observer);
+      if (el.__tap__.click) el.removeEventListener('click', tap.observer, false);
       else {
         window.removeEventListener('scroll', el.__tap__.scroll, true);
-        el.removeEventListener('touchmove', tap.observer);
-        el.removeEventListener('touchcancel', tap.observer);
-        el.removeEventListener('touchend', tap.observer);
+        el.removeEventListener('touchmove', tap.observer, false);
+        el.removeEventListener('touchcancel', tap.observer, false);
+        el.removeEventListener('touchend', tap.observer, false);
       }
       delete el.__tap__;
     }
@@ -1127,6 +1127,6 @@ for (z in UIEventProto){
 
   doc.addEventListener('WebComponentsReady', function(){
     xtag.fireEvent(doc.body, 'DOMComponentsLoaded');
-  });
+  }, false);
 
 })();

--- a/src/core.js
+++ b/src/core.js
@@ -878,7 +878,7 @@
       event._attach.forEach(function(obj) {
         xtag.removeEvent(element, obj);
       });
-      element.removeEventListener(event.type, event.stack);
+      element.removeEventListener(event.type, event.stack, false);
     },
 
     removeEvents: function(element, obj){
@@ -1006,13 +1006,13 @@ for (z in UIEventProto){
   function addTap(el, tap, e){
     if (!el.__tap__) {
       el.__tap__ = { click: e.type == 'mousedown' };
-      if (el.__tap__.click) el.addEventListener('click', tap.observer);
+      if (el.__tap__.click) el.addEventListener('click', tap.observer, false);
       else {
         el.__tap__.scroll = tap.observer.bind(el);
         window.addEventListener('scroll', el.__tap__.scroll, true);
-        el.addEventListener('touchmove', tap.observer);
-        el.addEventListener('touchcancel', tap.observer);
-        el.addEventListener('touchend', tap.observer);
+        el.addEventListener('touchmove', tap.observer, false);
+        el.addEventListener('touchcancel', tap.observer, false);
+        el.addEventListener('touchend', tap.observer, false);
       }
     }
     if (!el.__tap__.click) {
@@ -1023,12 +1023,12 @@ for (z in UIEventProto){
 
   function removeTap(el, tap){
     if (el.__tap__) {
-      if (el.__tap__.click) el.removeEventListener('click', tap.observer);
+      if (el.__tap__.click) el.removeEventListener('click', tap.observer, false);
       else {
         window.removeEventListener('scroll', el.__tap__.scroll, true);
-        el.removeEventListener('touchmove', tap.observer);
-        el.removeEventListener('touchcancel', tap.observer);
-        el.removeEventListener('touchend', tap.observer);
+        el.removeEventListener('touchmove', tap.observer, false);
+        el.removeEventListener('touchcancel', tap.observer, false);
+        el.removeEventListener('touchend', tap.observer, false);
       }
       delete el.__tap__;
     }
@@ -1086,6 +1086,6 @@ for (z in UIEventProto){
 
   doc.addEventListener('WebComponentsReady', function(){
     xtag.fireEvent(doc.body, 'DOMComponentsLoaded');
-  });
+  }, false);
 
 })();


### PR DESCRIPTION
- addEventListener/removeEventListener
  [22:14:10.475] uncaught exception: [Exception... "Not enough arguments"  nsresult: "0x80570001 (NS_ERROR_XPC_NOT_ENOUGH_ARGS)"  location: "JS frame :: ..... :: whenDocumentReady :: line 2219"  data: no]
- CustomEvent
  [22:32:20.137] [Exception... "Operation is not supported"  code: "9" nsresult: "0x80530009 (NS_ERROR_DOM_NOT_SUPPORTED_ERR)"  location: "Web Console Line: 1"]
