### PR TITLE
Added attribute -> property synchronization

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -368,8 +368,13 @@
           return output;
         }, enumerable: true };
       }
-      if (tag.lifecycle.attributeChanged) tag.prototype.attributeChangedCallback = { value: tag.lifecycle.attributeChanged, enumerable: true };
-
+      if (tag.lifecycle.attributeChanged) {
+        tag.prototype.attributeChangedCallback = { value: function(name, old, value){
+          var attr = tag.attributes[name.toLowerCase()];
+          if (attr && attr.sync) attr.setter.call(this, attr.boolean ? value !== null : value, old);
+          tag.lifecycle.attributeChanged.call(this, name, old, value);
+        }, enumerable: true };
+      }
       tag.prototype.setAttribute = {
         writable: true,
         enumerable: true,


### PR DESCRIPTION
I added a sync-property to the attribute definition (attribute: { sync: true }) to automatically update the inner property when the attribute is altered after the element is created. In this way your setters will also be called when you change an attribute with JavaScript (or DevTools for that matter).