### PR TITLE
Ensure object exists before accessing .mixin

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -135,7 +135,7 @@
     var index = mixins.length;
     while (index--){
       output.unshift(mixins[index]);
-      if (xtag.mixins[mixins[index]].mixins) resolveMixins(xtag.mixins[mixins[index]].mixins, output);
+      if (xtag.mixins[mixins[index]] && xtag.mixins[mixins[index]].mixins) resolveMixins(xtag.mixins[mixins[index]].mixins, output);
     }
     return output;
   }


### PR DESCRIPTION
Tried using x-switch, but it blew up.  This fixes it.