### PR TITLE
Fix for prefix detection on IE

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -32,8 +32,15 @@
         * prefix.js: addresses prefixed APIs present in global and non-Element contexts
     */
     prefix = (function () {
-      var keys = Object.keys(window).join();
-      var pre = ((keys.match(/,(ms)/) || keys.match(/,(moz)/) || keys.match(/,(O)/)) || [null, 'webkit'])[1].toLowerCase();
+      function findPrefix(obj) {
+        var keys = Object.keys(obj).join(),
+            matches = keys.match(/,(ms)/) || keys.match(/,(moz)/) || keys.match(/,(webkit)/) || keys.match(/,(O)/);
+
+        if (matches) return matches[1].toLowerCase();
+      }
+
+      var pre = findPrefix(window) || findPrefix(Object.getPrototypeOf(window)) || 'webkit';
+
       return {
         dom: pre == 'ms' ? 'MS' : pre,
         lowercase: pre,


### PR DESCRIPTION
This is a proposed solution for #164.  The issue there is that x-tag looks for an `ms` prefix in `window`, but won't find one there in IE11.  On that browser (and presumably IE10 too) it needs to instead look in window's prototype.

I've tested this by running the specs on Firefox, Chrome, IE11 and Edge, but not IE<11.  The patch uses `Object.getPrototypeOf()`, which should be available on IE9+ according to caniuse.

I get that this code also needs to work on lots of browsers that I don't have access to, so I've tried to keep the logic similar to what was already there.  I did however add a match on `/,(webkit)/` before `/,(O)/` ...

Happy to iterate on this if you have any feedback.