### PR TITLE
Enhance tap event for web accessibility

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -458,11 +458,18 @@
         }
       },
       tap: {
-        attach: ['pointerdown', 'pointerup'],
+          attach: ['pointerdown', 'pointerup', 'keypress'],
         condition: function(event, custom){
           if (event.type == 'pointerdown') {
             custom.startX = event.clientX;
             custom.startY = event.clientY;
+          }
+          else if (event.type == 'keypress') {
+              if (event.which == 13 || event.which == 32) {
+                  return true;
+              } else {
+                  return false;
+              }
           }
           else if (event.button === 0 &&
                    Math.abs(custom.startX - event.clientX) < 10 &&


### PR DESCRIPTION
The tap event as it works now is not fully accessible. This PR add a keypress check for the enter key and the spacebar and treats them as tap events as well.