### PR TITLE
pseudos spec

### DIFF
--- a/tests/core/spec.js
+++ b/tests/core/spec.js
@@ -395,6 +395,9 @@ describe("X-Tag pseudos should", function() {
     xtag.pseudos.foo = {
       onInvoke(){
         count++;
+      },
+      onParse() {
+        count++;
       }
     }
 


### PR DESCRIPTION
This part of the spec I'm confused with...sort of, I just want to make sure. 

In the case above i added the onParse method so does that mean you expect the count to be 9, but only when a fn parameter is included otherwise it would still be 6?

That's what the docs make it sound like [to me], do  I have this correct based off of the docs?